### PR TITLE
Fix for wrong stash being used and moving method parameter to body parameters

### DIFF
--- a/lib/Mojolicious/Plugin/MethodOverride.pm
+++ b/lib/Mojolicious/Plugin/MethodOverride.pm
@@ -38,11 +38,8 @@ sub register {
                 $req->headers->remove($header);
             }
             elsif (defined $param) {
-                for ($req->url->query) {
-                    $method = $_->param($param)
-                        or return 1;
-                    $_->remove($param);
-                }
+                $method = $req->body_params->param($param) or return 1;
+                $req->body_params->remove($param);
             }
 
             if ($method and $method =~ /^[A-Za-z]+$/) {


### PR DESCRIPTION
In `after_static` hook, wrong `stash` is being used because `register's` object was used instead of hooked controller's one.
Since there's already a requirement for delivering method to be POST, `body_params` is better way to transmit overridden method.
