### PR TITLE
add minimum perl version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,6 @@ use inc::Module::Install;
 
 name            'Mojolicious-Plugin-MethodOverride';
 all_from        'lib/Mojolicious/Plugin/MethodOverride.pm';
-readme_from;
 author          q{Bernhard Graf <graf@cpan.org>};
 license         'perl';
 repository      'git://github.com/augensalat/mojolicious-plugin-methodoverride.git';
@@ -11,6 +10,8 @@ build_requires  'Test::More';
 build_requires  'Test::Mojo';
 
 requires        'Mojolicious' => '3.21';
+
+perl_version    '5.10';
 
 auto_install;
 


### PR DESCRIPTION
cleanup [CPANTS] (http://cpants.cpanauthors.org/dist/Mojolicious-Plugin-MethodOverride) metadata warning - used perlver to determine minimum version - empty readme_from was causing Makefile.PL warnings