### PR TITLE
use GNU tar for portability

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,5 +14,9 @@ requires        'Mojolicious' => '3.21';
 
 auto_install;
 
+makemaker_args(
+    dist => { TAR => 'gtar' },
+);
+
 WriteAll;
 


### PR DESCRIPTION
use GNU tar for build to resolve CPANTS pax header warnings
